### PR TITLE
Move localization data objects to source file root in order to reduce allocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,23 +41,23 @@ function Tutorial() {
 …when transpiled with this custom AST transformer, the output will look like this:
 
 ```js
+var l10n$tutorial_welcome_headline = {
+    en: 'Welcome to %{workspace_name}',
+    th: 'ยินดีต้อนรับเข้าสู่ %{workspace_name}',
+  },
+  l10n$tutorial_welcome_paragraph = {
+    en: 'Your team will have all that you need to get work done.',
+    th: 'บริหารจัดการงานได้อย่างครบถ้วนและมีประสิทธิภาพ',
+  }
 function Tutorial() {
   return (
     <section>
       <h1>
-        {__(
-          __.$('tutorial.welcome.headline', {
-            en: 'Welcome to %{workspace_name}',
-            th: 'ยินดีต้อนรับเข้าสู่ %{workspace_name}',
-          })
-        )}
+        {__(__.$('tutorial.welcome.headline', l10n$tutorial_welcome_headline))}
       </h1>
       <p>
         {__(
-          __.$('tutorial.welcome.paragraph', {
-            en: 'Your team will have all that you need to get work done.',
-            th: 'บริหารจัดการงานได้อย่างครบถ้วนและมีประสิทธิภาพ',
-          })
+          __.$('tutorial.welcome.paragraph', l10n$tutorial_welcome_paragraph)
         )}
       </p>
     </section>

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "typescript": "^3.2.2"
   },
   "name": "@taskworld/typescript-custom-transformer-l10n",
-  "version": "2.1.0",
+  "version": "3.0.0-0",
   "description": "A TypeScript Custom AST transformer that inlines localization strings into the source code",
   "main": "transformer.js",
   "dependencies": {},


### PR DESCRIPTION
From profiling, a lot of l10n data objects are allocated in hot code paths, e.g. in some React component’s `render()` method.

This branch will be merged after the change is verified on production.